### PR TITLE
fix: execute command cwd path and root dir  

### DIFF
--- a/src/helpers/general.ts
+++ b/src/helpers/general.ts
@@ -27,14 +27,7 @@ export const executeCommand = async (
   command: string,
   options?: ExecOptions
 ) => {
-  let execOptions = options;
-
-  if (!options) {
-    const currentPath = getCurrentPath();
-    execOptions = {
-      cwd: currentPath,
-    };
-  }
+  let execOptions = { ...options, cwd: options?.cwd ?? getCurrentPath() };
 
   try {
     const { stdout } = await exec(command, execOptions);

--- a/src/helpers/worktree/getWorktrees.ts
+++ b/src/helpers/worktree/getWorktrees.ts
@@ -1,6 +1,6 @@
 import { executeCommand } from '#/helpers/general';
 import { BARE_REPOSITORY } from '#/src/config/constants';
-import { getCurrentBranchName } from '../git';
+import { getCurrentBranchName, isInsideBareRepository } from '../git';
 import { removeFirstAndLastCharacter } from '../string';
 
 export const getWorktrees = async (
@@ -12,10 +12,12 @@ export const getWorktrees = async (
   try {
     const { stdout } = await executeCommand(command);
 
+    const isRootDirectory = await isInsideBareRepository();
+
     const worktrees = await getFilteredWorktrees(
       stdout,
       withBareRepo,
-      showCurrentWorktree
+      isRootDirectory || showCurrentWorktree
     );
 
     return worktrees;


### PR DESCRIPTION
- Set the execute command cwd path to currentPath when no override is given
- When at the root directory, i.e not in a worktree, then we should show all worktrees