### PR TITLE
refactor(add): tracking branch and sort

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,9 @@ This extension has the following settings:
 
 Automatically push worktrees to remote
 
-- `gitWorktree.worktree.shouldPushBranchAutomatically`: No
+> :warning: **If you turn this off **: Then the tracking branch will not get updated to your new branch and you will have to run the publish command to fix
+
+- `gitWorktree.worktree.shouldPushBranchAutomatically`: Yes
 
 Set logging level for extension
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,19 @@ much cleaner and cleaner to manage
 
 You can choose to create a new worktree or create one from a remote branch that exists in your repository
 
+##### Create new worktree
+
+- Command Palette -> 'Git Worktree: Add'
+- Select 'Create new worktree'
+- Set a name for the worktree
+- Set your tracking branch (think of this as your base branch, normally this is `main` or `master`)
+
 ![add-local](https://user-images.githubusercontent.com/39385802/200139178-a6246556-6d6a-4997-a4b8-d593871e7207.gif)
+
+##### Add remote worktree
+
+- Command Palette -> 'Git Worktree: Add'
+- Select remote worktree
 
 ![add-remote](https://user-images.githubusercontent.com/39385802/200139183-c34598c5-62d0-4ed5-8c52-ba44c8faf01d.gif)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "git-worktree",
-  "version": "1.1.3",
+  "version": "1.2.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "git-worktree",
-      "version": "1.1.3",
+      "version": "1.2.2",
       "dependencies": {
         "parse-url": "^8.1.0"
       },

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
         "properties": {
           "gitWorktree.worktree.automatically": {
             "type": "string",
-            "default": "No",
+            "default": "Yes",
             "description": "Should push worktree automatically to remote",
             "enum": [
               "No",

--- a/src/commands/add.ts
+++ b/src/commands/add.ts
@@ -15,6 +15,7 @@ import { addNewWorktree } from '../helpers/worktree/addNewWorktree';
 import { addRemoteWorktree } from '../helpers/worktree/addRemoteWorktree';
 import { getWorktrees } from '../helpers/worktree/getWorktrees';
 import { shouldMoveIntoWorktree } from '../helpers/worktree/shouldMoveIntoWorktree';
+import { sortBranches } from '../helpers/worktree/sortBranches';
 import { shouldPushWorktree } from './rename';
 
 const createWorktreeOption = 'Create new worktree';
@@ -67,12 +68,22 @@ export const add = async () => {
           "Aborted as worktree wasn't given a name"
         );
 
-      let trackingBranch = await window.showQuickPick(remoteBranches, {
+      const sortedRemoteBranches = sortBranches(
+        remoteBranches.map((branch) => ({ label: branch }))
+      );
+
+      let trackingBranch = await window.showQuickPick(sortedRemoteBranches, {
         placeHolder: 'Select remote branch to track',
         ignoreFocusOut: settings.shouldCloseOnBlur,
       });
 
-      worktree = await addNewWorktree(newBranch, trackingBranch);
+      if (!trackingBranch)
+        return showUserMessage(
+          'Warn',
+          'Aborted as no tracking branch was selected'
+        );
+
+      worktree = await addNewWorktree(newBranch, trackingBranch.label);
 
       await shouldPushWorktree(worktree);
     } else {

--- a/src/helpers/worktree/sortBranches.ts
+++ b/src/helpers/worktree/sortBranches.ts
@@ -1,0 +1,47 @@
+import { QuickPickItemKind, type QuickPickItem } from 'vscode';
+
+export const sortBranches = (incomingArr: QuickPickItem[]) => {
+  const arr: QuickPickItem[] = [...incomingArr];
+
+  const customSort = (a: QuickPickItem, b: QuickPickItem) => {
+    // Check if a or b is "main" or "master"
+    const aIsMainOrMaster = /^(main|master)$/i.test(a.label);
+    const bIsMainOrMaster = /^(main|master)$/i.test(b.label);
+
+    if (aIsMainOrMaster && bIsMainOrMaster) {
+      // If both a and b are "main" or "master", sort them lexicographically
+      return a.label.localeCompare(b.label);
+    } else if (aIsMainOrMaster) {
+      // If only a is "main" or "master", prioritize it to be at the top
+      return -1;
+    } else if (bIsMainOrMaster) {
+      // If only b is "main" or "master", prioritize it to be at the top
+      return 1;
+    } else {
+      // Otherwise, sort them lexicographically
+      return a.label.localeCompare(b.label);
+    }
+  };
+
+  // Sort the array using the custom sorting function
+  arr.sort(customSort);
+
+  // Reverse the array
+  arr.reverse();
+
+  // Find the last index of "main" or "master" in the reversed array
+  const lastIndex = arr.findIndex((item) =>
+    /^(main|master)$/i.test(item.label)
+  );
+
+  // If "main" or "master" is found, insert a separator after it
+  if (lastIndex !== -1)
+    arr.splice(lastIndex, 0, {
+      label: '',
+      kind: QuickPickItemKind.Separator,
+    });
+
+  arr.reverse();
+
+  return arr;
+};


### PR DESCRIPTION
### Changes

- add steps to readme around adding new worktrees
- abort when tracking branch wasn't selected
- sort tracking branches and have `main` and `master` branch to be always at the top
- change push automatically to be defaulted to 'Yes'

closes #6 